### PR TITLE
add item displays

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -6,7 +6,7 @@ plugins {
 def id = "SpiritChat"
 def group = 'software.lmao.spiritchat'
 def platform = "Paper"
-def version = '0.1.2'
+def version = '0.2.2'
 
 repositories {
     mavenCentral()

--- a/server/src/main/java/software/lmao/spiritchat/config/SpiritChatConfig.java
+++ b/server/src/main/java/software/lmao/spiritchat/config/SpiritChatConfig.java
@@ -66,6 +66,13 @@ public class SpiritChatConfig {
 
         @Comment({
                 "",
+                "Whether or not to use {i} and {item} to display",
+                "the item a player is holding in chat."
+        })
+        private boolean useItemDisplay = true;
+
+        @Comment({
+                "",
                 "Whether or not to use the static format for chat messages.",
         })
         private boolean useStaticFormat = true;
@@ -98,6 +105,10 @@ public class SpiritChatConfig {
                 "default", "<gray>%username%</gray> <dark_gray>></dark_gray> <white>%message%</white>",
                 "admin", "<red>[Admin]</red> <white>%username%</white> <dark_gray>></dark_gray> <red>%message%</red>"
         ));
+
+        public boolean useItemDisplay() {
+            return useItemDisplay;
+        }
 
         public boolean useStaticFormat() {
             return useStaticFormat;

--- a/server/src/main/java/software/lmao/spiritchat/listener/PlayerChatListener.java
+++ b/server/src/main/java/software/lmao/spiritchat/listener/PlayerChatListener.java
@@ -20,6 +20,7 @@ import net.luckperms.api.model.user.User;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import software.lmao.spiritchat.SpiritChatPlugin;
 import software.lmao.spiritchat.config.SpiritChatConfig;
@@ -30,6 +31,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class PlayerChatListener implements Listener {
@@ -64,6 +66,14 @@ public class PlayerChatListener implements Listener {
                 builder = builder.replace("%message%", MiniMessage.miniMessage().serialize(component));
             } else {
                 builder = builder.replace("%message%", PlainTextComponentSerializer.plainText().serialize(message));
+            }
+
+            if (format().useItemDisplay() && source.hasPermission(Perm.CHAT_ITEM)) {
+                ItemStack item = source.getInventory().getItemInMainHand();
+                String itemMiniMessage = MiniMessage.miniMessage().serialize(item.displayName());
+
+                builder = builder.replace(Pattern.quote("{i}"), itemMiniMessage);
+                builder = builder.replace("\\{item\\}", itemMiniMessage);
             }
 
             return builder.asComponent(source);
@@ -121,6 +131,14 @@ public class PlayerChatListener implements Listener {
                     builder = builder.replace("%message%", MiniMessage.miniMessage().serialize(component));
                 } else {
                     builder = builder.replace("%message%", PlainTextComponentSerializer.plainText().serialize(message));
+                }
+
+                if (format().useItemDisplay() && source.hasPermission(Perm.CHAT_ITEM)) {
+                    ItemStack item = source.getInventory().getItemInMainHand();
+                    String itemMiniMessage = MiniMessage.miniMessage().serialize(item.displayName());
+
+                    builder = builder.replace(Pattern.quote("{i}"), itemMiniMessage);
+                    builder = builder.replace("\\{item\\}", itemMiniMessage);
                 }
 
                 return builder.asComponent(source);

--- a/server/src/main/java/software/lmao/spiritchat/permission/Perm.java
+++ b/server/src/main/java/software/lmao/spiritchat/permission/Perm.java
@@ -18,6 +18,8 @@ public class Perm extends Permission {
 
     public static final Perm CHAT_COLORS = new Perm("chat-colors");
 
+    public static final Perm CHAT_ITEM = new Perm("chat-item");
+
     public Perm(@NotNull String name, @Nullable String description, @Nullable PermissionDefault defaultValue, @Nullable Map<String, Boolean> children) {
         super(PREFIX + "." + name, description, defaultValue, children);
 


### PR DESCRIPTION
This pull request introduces several changes to the `SpiritChat` plugin, including a version update, a new feature for item display in chat, and necessary permissions for the new feature. The most important changes are listed below:

### Version Update:
* Updated the version of the `SpiritChat` plugin from `0.1.2` to `0.2.2` in `server/build.gradle`.

### New Feature - Item Display in Chat:
* Added a new configuration option `useItemDisplay` in `SpiritChatConfig.java` to enable or disable displaying the item a player is holding in chat.
* Implemented the `useItemDisplay` method in the `Format` class of `SpiritChatConfig.java`.
* Enhanced `PlayerChatListener.java` to include item display functionality using `MiniMessage` for players with the appropriate permission. [[1]](diffhunk://#diff-3ec9135837dc7f183e05f2d19e0ca386d75759822a50cab55d25bb75571fa2d1R71-R78) [[2]](diffhunk://#diff-3ec9135837dc7f183e05f2d19e0ca386d75759822a50cab55d25bb75571fa2d1R136-R143)

### Permissions:
* Added a new permission `CHAT_ITEM` in `Perm.java` to control the ability to display items in chat.